### PR TITLE
Add Smithery to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-```markdown
 # MCP REST API Tester
 [![smithery badge](https://smithery.ai/badge/dkmaker-mcp-rest-api)](https://smithery.ai/server/dkmaker-mcp-rest-api)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -20,6 +19,7 @@ To install REST API Tester for Claude Desktop automatically via [Smithery](https
 npx -y @smithery/cli install dkmaker-mcp-rest-api --client claude
 ```
 
+### Installing Manually
 1. Install the package globally:
 ```bash
 npm install -g dkmaker-mcp-rest-api
@@ -167,4 +167,3 @@ npm run watch
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
+```markdown
 # MCP REST API Tester
+[![smithery badge](https://smithery.ai/badge/dkmaker-mcp-rest-api)](https://smithery.ai/server/dkmaker-mcp-rest-api)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![NPM Package](https://img.shields.io/npm/v/dkmaker-mcp-rest-api.svg)](https://www.npmjs.com/package/dkmaker-mcp-rest-api)
 
@@ -9,6 +11,14 @@ A TypeScript-based MCP server that enables testing of REST APIs through Cline. T
 </a>
 
 ## Installation
+
+### Installing via Smithery
+
+To install REST API Tester for Claude Desktop automatically via [Smithery](https://smithery.ai/server/dkmaker-mcp-rest-api):
+
+```bash
+npx -y @smithery/cli install dkmaker-mcp-rest-api --client claude
+```
 
 1. Install the package globally:
 ```bash
@@ -157,3 +167,4 @@ npm run watch
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+```


### PR DESCRIPTION
This PR makes two changes to the README.

1. Adds installation instructions to automatically install REST API Tester for Claude Desktop using Smithery CLI. This makes it easier for users to install the MCP.
2. Adds a badge to show the number of installations from Smithery: https://smithery.ai/server/dkmaker-mcp-rest-api

Let me know if any tweaks have to be made!