### PR TITLE
feat: add support for per-request host override in REST API tester

### DIFF
--- a/src/resources/examples.md
+++ b/src/resources/examples.md
@@ -1,16 +1,21 @@
 # REST API Testing Examples
 
-⚠️ IMPORTANT: Only provide the endpoint path - do not include full URLs. Your path will be automatically resolved to the full URL.
+⚠️ IMPORTANT:
+- Only provide the endpoint path in the `endpoint` argument—do not include full URLs. Your path will be automatically resolved to the full URL using the configured base URL or the optional `host` argument.
+- To override the base URL for a single request, use the optional `host` argument. This must be a valid URL starting with `http://` or `https://`, and may include a path (trailing slashes will be removed).
 
 For example, if the base URL is `http://localhost:3000`:
 ✅ Correct: `"/api/users"` → Resolves to: `http://localhost:3000/api/users`
 ❌ Incorrect: `"http://localhost:3000/api/users"` or `"www.example.com/api/users"`
 
+If you use a `host` argument:
+✅ Correct: `"host": "https://api.example.com/v1", "endpoint": "/users"` → Resolves to: `https://api.example.com/v1/users`
+
 ## Basic GET Request
 ```typescript
 use_mcp_tool('rest-api', 'test_request', {
   "method": "GET",
-  "endpoint": "/users"  // Will be appended to REST_BASE_URL
+  "endpoint": "/users"  // Will be appended to REST_BASE_URL or 'host' if provided
 });
 ```
 
@@ -18,7 +23,7 @@ use_mcp_tool('rest-api', 'test_request', {
 ```typescript
 use_mcp_tool('rest-api', 'test_request', {
   "method": "GET",
-  "endpoint": "/users?role=admin&status=active"
+  "endpoint": "/users?role=admin&status=active" // Always a path, not a full URL
 });
 ```
 
@@ -66,8 +71,24 @@ use_mcp_tool('rest-api', 'test_request', {
 });
 ```
 
+## Using the Optional `host` Argument
+You can override the default base URL for a single request by providing a `host` argument. This must be a valid URL starting with `http://` or `https://`, and may include a path (trailing slashes will be removed).
+
+```typescript
+use_mcp_tool('rest-api', 'test_request', {
+  "method": "GET",
+  "endpoint": "/users",
+  "host": "https://api.example.com/v1" // The request will go to https://api.example.com/v1/users
+});
+```
+
+- The `host` argument must include the protocol (http or https).
+- If a path is included, any trailing slash will be removed.
+- If `host` is invalid, you will receive a clear error message.
+- The `endpoint` argument must always be a path, never a full URL.
+
 ## Changing Base URL
-If you need to test against a different base URL, update the base URL configuration rather than including the full URL in the endpoint parameter.
+If you need to test against a different base URL for all requests, update the base URL configuration rather than including the full URL in the endpoint parameter. For a single request, use the `host` argument as shown above.
 
 Example:
 ```bash
@@ -78,3 +99,6 @@ Example:
 # 1. Update the base URL configuration to: https://api.example.com
 # 2. Then use just the path:
 ✅ "endpoint": "/users"  # This will resolve to: https://api.example.com/users
+# Or, for a single request:
+✅ "host": "https://api.example.com", "endpoint": "/users"  # This will resolve to: https://api.example.com/users
+```


### PR DESCRIPTION
Instead of always having to change the `REST_BASE_URL` everytime you want to test a different API provider, I've added support for an optional host argument to override the base URL for individual REST API test requests. The host value is validated to ensure it is a valid http(s) URL and may include a path (with any trailing slash removed).

example usage: 
```ts
use_mcp_tool('rest-api', 'test_request', {
  "method": "GET",
  "endpoint": "/users",
  "host": "https://api.example.com/v1" // The request will go to https://api.example.com/v1/users
});
```